### PR TITLE
Remove obsolete deps; replace with vanilla Node.js and maintained alternatives

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
 
 	var SimManager = require('./grunt/sim-manager')(grunt);
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 	grunt.registerTask('create-no-jekyll', function(){
 		grunt.file.write('./dist/.nojekyll', '');

--- a/arrow-test/Gruntfile.js
+++ b/arrow-test/Gruntfile.js
@@ -114,7 +114,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/arrow-test/package.json
+++ b/arrow-test/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/battery-resistor-circuit/Gruntfile.js
+++ b/battery-resistor-circuit/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/battery-resistor-circuit/package.json
+++ b/battery-resistor-circuit/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/bending-light/Gruntfile.js
+++ b/bending-light/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 	grunt.registerTask('default', [
 		'watch'

--- a/bending-light/package.json
+++ b/bending-light/package.json
@@ -46,13 +46,13 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "sat": "^0.9.0",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/beta-decay/Gruntfile.js
+++ b/beta-decay/Gruntfile.js
@@ -135,7 +135,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/beta-decay/package.json
+++ b/beta-decay/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/capacitor-lab/Gruntfile.js
+++ b/capacitor-lab/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/capacitor-lab/package.json
+++ b/capacitor-lab/package.json
@@ -45,13 +45,13 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "sat": "^0.9.0",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/charges-and-fields/Gruntfile.js
+++ b/charges-and-fields/Gruntfile.js
@@ -125,7 +125,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/charges-and-fields/package.json
+++ b/charges-and-fields/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/circuit-construction-kit-dc-only/Gruntfile.js
+++ b/circuit-construction-kit-dc-only/Gruntfile.js
@@ -129,7 +129,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/circuit-construction-kit-dc-only/package.json
+++ b/circuit-construction-kit-dc-only/package.json
@@ -46,14 +46,14 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "phantomjs-polyfill": "0.0.1",
     "requirejs": "^2.3.7",
     "sat": "^0.9.0",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/circuit-construction-kit/Gruntfile.js
+++ b/circuit-construction-kit/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/circuit-construction-kit/package.json
+++ b/circuit-construction-kit/package.json
@@ -46,14 +46,14 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "phantomjs-polyfill": "0.0.1",
     "requirejs": "^2.3.7",
     "sat": "^0.9.0",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/collision-lab/Gruntfile.js
+++ b/collision-lab/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/collision-lab/package.json
+++ b/collision-lab/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/common/Gruntfile.js
+++ b/common/Gruntfile.js
@@ -93,7 +93,7 @@ module.exports = function(grunt){
         }
     });
 
-    require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+    require('load-grunt-tasks')(grunt);
 
     grunt.registerTask('build_tests', function(){
         var options = this.options();

--- a/common/package.json
+++ b/common/package.json
@@ -25,9 +25,7 @@
   "devDependencies": {
     "backbone": "^1.1.2",
     "bootstrap": "^5.3.8",
-    "bower": "^1.3.9",
-    "chai": "^1.10.0",
-    "chai-stats": "^0.3.0",
+    "chai": "^5.0.0",
     "font-awesome": "^4.2.0",
     "grunt-contrib-jshint": "^3.2.0",
     "grunt-mocha": "^1.2.0",
@@ -39,7 +37,7 @@
     "rectangle-node": "0.0.1",
     "requirejs": "^2.3.7",
     "requirejs-text": "^2.0.12",
-    "sinon": "^1.12.2",
+    "sinon": "^19.0.0",
     "solve-quadratic-equation": "^0.1.0",
     "underscore": "^1.13.8",
     "vector2-node": "0.0.3"

--- a/common/test/index.template.html
+++ b/common/test/index.template.html
@@ -7,9 +7,8 @@
 
 		<link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
 
-		<script type="text/javascript" src="../node_modules/sinon/pkg/sinon-1.12.2.js"></script>
+		<script type="text/javascript" src="../node_modules/sinon/pkg/sinon.js"></script>
 		<script type="text/javascript" src="../node_modules/chai/chai.js"></script>
-		<script type="text/javascript" src="../node_modules/chai-stats/chai-stats.js"></script>
 		<script type="text/javascript" src="../node_modules/mocha/mocha.js"></script>
 		<script type="text/javascript" src="../node_modules/requirejs/require.js"></script>
 	</head>

--- a/common/v3/Gruntfile.js
+++ b/common/v3/Gruntfile.js
@@ -90,7 +90,7 @@ module.exports = function(grunt){
         }
     });
 
-    require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+    require('load-grunt-tasks')(grunt);
 
     grunt.registerTask('build_tests', function(){
         var options = this.options();

--- a/common/v3/package.json
+++ b/common/v3/package.json
@@ -25,9 +25,7 @@
   "devDependencies": {
     "backbone": "^1.1.2",
     "bootstrap": "^3.2.0",
-    "bower": "^1.3.9",
-    "chai": "^1.10.0",
-    "chai-stats": "^0.3.0",
+    "chai": "^5.0.0",
     "font-awesome": "^4.2.0",
     "grunt-contrib-jshint": "^3.2.0",
     "grunt-mocha": "^1.2.0",
@@ -39,7 +37,7 @@
     "rectangle-node": "0.0.1",
     "requirejs": "^2.1.15",
     "requirejs-text": "^2.0.12",
-    "sinon": "^1.12.2",
+    "sinon": "^19.0.0",
     "solve-quadratic-equation": "^0.1.0",
     "underscore": "^1.13.8",
     "vector2-node": "0.0.3"

--- a/common/v3/test/index.template.html
+++ b/common/v3/test/index.template.html
@@ -7,9 +7,8 @@
 
 		<link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
 
-		<script type="text/javascript" src="../node_modules/sinon/pkg/sinon-1.12.2.js"></script>
+		<script type="text/javascript" src="../node_modules/sinon/pkg/sinon.js"></script>
 		<script type="text/javascript" src="../node_modules/chai/chai.js"></script>
-		<script type="text/javascript" src="../node_modules/chai-stats/chai-stats.js"></script>
 		<script type="text/javascript" src="../node_modules/mocha/mocha.js"></script>
 		<script type="text/javascript" src="../node_modules/requirejs/require.js"></script>
 	</head>

--- a/discharge-lamps/Gruntfile.js
+++ b/discharge-lamps/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/discharge-lamps/package.json
+++ b/discharge-lamps/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/electric-field-of-dreams/Gruntfile.js
+++ b/electric-field-of-dreams/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/electric-field-of-dreams/package.json
+++ b/electric-field-of-dreams/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/energy-forms-and-changes/Gruntfile.js
+++ b/energy-forms-and-changes/Gruntfile.js
@@ -148,7 +148,7 @@ module.exports = function(grunt){
         }
     });
 
-    require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+    require('load-grunt-tasks')(grunt);
 
 
         // Build the template, replacing {{ test }} with the list of test files

--- a/energy-forms-and-changes/package.json
+++ b/energy-forms-and-changes/package.json
@@ -46,12 +46,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/faraday/Gruntfile.js
+++ b/faraday/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/faraday/package.json
+++ b/faraday/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/generator/Gruntfile.js
+++ b/generator/Gruntfile.js
@@ -109,7 +109,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/generator/package.json
+++ b/generator/package.json
@@ -44,9 +44,9 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
-    "underscore": "^1.13.8"
+    "underscore": "^1.13.8",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/geometric-optics/Gruntfile.js
+++ b/geometric-optics/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/geometric-optics/package.json
+++ b/geometric-optics/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/gravity-and-orbits/Gruntfile.js
+++ b/gravity-and-orbits/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/gravity-and-orbits/package.json
+++ b/gravity-and-orbits/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/greenhouse-effect/Gruntfile.js
+++ b/greenhouse-effect/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/greenhouse-effect/package.json
+++ b/greenhouse-effect/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/grunt/sim-manager.js
+++ b/grunt/sim-manager.js
@@ -1,6 +1,4 @@
-var _      = require('underscore');
-var touch  = require('touch');
-var fse    = require('fs-extra');
+var fs = require('fs');
 
 module.exports = function(grunt) {
 
@@ -35,13 +33,12 @@ module.exports = function(grunt) {
 		 */
 		getAllSimDirs: function() {
 			var gruntfiles = this.getAllSimGruntfiles();
-			var dirs = _.map(gruntfiles, function(gruntfile) {
-				// Gets the path leading up to Gruntfile.js
+			var dirs = gruntfiles.map(function(gruntfile) {
 				return gruntfile.substring(0, gruntfile.indexOf('Gruntfile.js'));
 			});
 
-			return _.reject(dirs, function(dir) {
-				return (dir.indexOf('common') !== -1);
+			return dirs.filter(function(dir) {
+				return (dir.indexOf('common') === -1);
 			});
 		},
 
@@ -99,7 +96,7 @@ module.exports = function(grunt) {
 		 * Extracts the names of the directories from a list of paths
 		 */
 		getDirNames: function(dirs) {
-			return _.map(dirs, function(dir) {
+			return dirs.map(function(dir) {
 				return dir.substring(dir.indexOf('/') + 1, dir.lastIndexOf('/'));
 			});
 		},
@@ -160,7 +157,7 @@ module.exports = function(grunt) {
 						grunt.log.writeln('   ' + dirNames[i]);
 
 					// Update the build timestamp
-					touch('.build_timestamp');
+					fs.closeSync(fs.openSync('.build_timestamp', 'w'));
 
 					done();
 				}
@@ -192,7 +189,7 @@ module.exports = function(grunt) {
 			for (var i = 0; i < simDirNames.length; i++) {
 				var directory = './dist/' + simDirNames[i];
 				if (grunt.file.exists(directory)) {
-					fse.removeSync(directory);
+					fs.rmSync(directory, {recursive: true, force: true});
 					dirsCleaned++;
 				}
 			}
@@ -223,7 +220,7 @@ module.exports = function(grunt) {
 				var dst = './dist/' + dirName;
 
 				if (grunt.file.exists(src)) {
-					fse.copySync(src, dst);
+					fs.cpSync(src, dst, {recursive: true});
 					dirsCopied++;
 				}
 			}
@@ -245,7 +242,7 @@ module.exports = function(grunt) {
 			var packageFiles = grunt.file.expand(packageFilePatterns);
 			if (!forceUpdateAll) {
 				var updatedSimDirNames = this.getUpdatedSimDirNames();
-				packageFiles = _.filter(packageFiles, function(packageFile) {
+				packageFiles = packageFiles.filter(function(packageFile) {
 					// It's good if it's in the common files
 					if (packageFile.indexOf('common') !== -1)
 						return true;
@@ -299,8 +296,7 @@ module.exports = function(grunt) {
 			// Get a list of all the package files from each directory
 			var packageFiles = grunt.file.expand(packageFilePatterns);
 			// Get a list of their containing directories
-			var dirs = _.map(packageFiles, function(packageFile) {
-				// Gets the path leading up to package.json
+			var dirs = packageFiles.map(function(packageFile) {
 				return packageFile.substring(0, packageFile.indexOf('package.json'));
 			});
 
@@ -308,7 +304,7 @@ module.exports = function(grunt) {
 			for (var i = 0; i < dirs.length; i++) {
 				var directory = dirs[i] + 'node_modules';
 				if (grunt.file.exists(directory)) {
-					fse.removeSync(directory);
+					fs.rmSync(directory, {recursive: true, force: true});
 					dirsCleaned++;
 				}
 			}
@@ -325,11 +321,11 @@ module.exports = function(grunt) {
 		createNewSim: function(dirName, packageName, classPrefix, title) {
 			// Remove the current template's /dist directory if it exists--just slows down the copy
 			if (grunt.file.exists('./template/dist/'))
-				fse.removeSync('./template/dist/');
+				fs.rmSync('./template/dist/', {recursive: true, force: true});
 
 			// Copy the template directory
 			var newDir = './' + dirName;
-			fse.copySync('./template/', newDir);
+			fs.cpSync('./template/', newDir, {recursive: true});
 
 			// Replace certain strings in certain files
 			var replacements = [

--- a/hydrogen-atom/Gruntfile.js
+++ b/hydrogen-atom/Gruntfile.js
@@ -140,7 +140,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/hydrogen-atom/package.json
+++ b/hydrogen-atom/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/ladybug-motion/Gruntfile.js
+++ b/ladybug-motion/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/ladybug-motion/package.json
+++ b/ladybug-motion/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/lasers/Gruntfile.js
+++ b/lasers/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/lasers/package.json
+++ b/lasers/package.json
@@ -46,12 +46,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/magnet-and-compass/Gruntfile.js
+++ b/magnet-and-compass/Gruntfile.js
@@ -109,7 +109,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/magnet-and-compass/package.json
+++ b/magnet-and-compass/package.json
@@ -44,9 +44,9 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
-    "underscore": "^1.13.8"
+    "underscore": "^1.13.8",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/magnets-and-electromagnets/Gruntfile.js
+++ b/magnets-and-electromagnets/Gruntfile.js
@@ -109,7 +109,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/magnets-and-electromagnets/package.json
+++ b/magnets-and-electromagnets/package.json
@@ -44,9 +44,9 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
-    "underscore": "^1.13.8"
+    "underscore": "^1.13.8",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/masses-and-springs/Gruntfile.js
+++ b/masses-and-springs/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/masses-and-springs/package.json
+++ b/masses-and-springs/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/maze-game/Gruntfile.js
+++ b/maze-game/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/maze-game/package.json
+++ b/maze-game/package.json
@@ -45,11 +45,11 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/moving-man/Gruntfile.js
+++ b/moving-man/Gruntfile.js
@@ -183,7 +183,7 @@ module.exports = function(grunt){
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 	grunt.registerTask('default', [
 		'watch'

--- a/moving-man/package.json
+++ b/moving-man/package.json
@@ -44,9 +44,9 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
-    "underscore": "^1.13.8"
+    "underscore": "^1.13.8",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/my-solar-system/Gruntfile.js
+++ b/my-solar-system/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/my-solar-system/package.json
+++ b/my-solar-system/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/nuclear-fission/Gruntfile.js
+++ b/nuclear-fission/Gruntfile.js
@@ -141,7 +141,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/nuclear-fission/package.json
+++ b/nuclear-fission/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/nuclear-physics/Gruntfile.js
+++ b/nuclear-physics/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/nuclear-physics/package.json
+++ b/nuclear-physics/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "homepage": "https://github.com/veillette/simulations",
   "devDependencies": {
-    "fs-extra": "^11.3.0",
     "grunt": "^1.6.1",
     "grunt-cli": "^1.5.0",
     "grunt-contrib-clean": "^2.0.1",
@@ -27,9 +26,7 @@
     "grunt-contrib-copy": "^1.0.0",
     "grunt-gh-pages": "^4.0.0",
     "grunt-targethtml": "^0.2.6",
-    "matchdep": "^1.0.0",
-    "touch": "^3.1.1",
-    "underscore": "^1.13.8"
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "braces": "^3.0.3",

--- a/pendulum-lab/Gruntfile.js
+++ b/pendulum-lab/Gruntfile.js
@@ -120,7 +120,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/pendulum-lab/package.json
+++ b/pendulum-lab/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/photoelectric-effect/Gruntfile.js
+++ b/photoelectric-effect/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/photoelectric-effect/package.json
+++ b/photoelectric-effect/package.json
@@ -46,12 +46,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/projectile-motion/Gruntfile.js
+++ b/projectile-motion/Gruntfile.js
@@ -114,7 +114,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/projectile-motion/package.json
+++ b/projectile-motion/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/radio-waves/Gruntfile.js
+++ b/radio-waves/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/radio-waves/package.json
+++ b/radio-waves/package.json
@@ -46,12 +46,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/radioactive-dating-game/Gruntfile.js
+++ b/radioactive-dating-game/Gruntfile.js
@@ -141,7 +141,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/radioactive-dating-game/package.json
+++ b/radioactive-dating-game/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/rutherford-scattering/Gruntfile.js
+++ b/rutherford-scattering/Gruntfile.js
@@ -134,7 +134,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/rutherford-scattering/package.json
+++ b/rutherford-scattering/package.json
@@ -45,13 +45,13 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "point-in-polygon": "^1.0.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/sound/Gruntfile.js
+++ b/sound/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/sound/package.json
+++ b/sound/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/states-of-matter/Gruntfile.js
+++ b/states-of-matter/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/states-of-matter/package.json
+++ b/states-of-matter/package.json
@@ -46,12 +46,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/template/Gruntfile.js
+++ b/template/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/template/package.json
+++ b/template/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/vector-addition/Gruntfile.js
+++ b/vector-addition/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt){
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/vector-addition/package.json
+++ b/vector-addition/package.json
@@ -45,12 +45,12 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
     "object-pool": "^0.2.0",
     "requirejs": "^2.3.7",
     "underscore": "^1.13.8",
-    "vector2-node": "0.0.3"
+    "vector2-node": "0.0.3",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",

--- a/wave-interference/Gruntfile.js
+++ b/wave-interference/Gruntfile.js
@@ -108,7 +108,7 @@ module.exports = function(grunt) {
 		}
 	});
 
-	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+	require('load-grunt-tasks')(grunt);
 
 
 		// Build the template, replacing {{ test }} with the list of test files

--- a/wave-interference/package.json
+++ b/wave-interference/package.json
@@ -45,9 +45,9 @@
     "karma-mocha": "^2.0.1",
     "karma-requirejs": "^1.1.0",
     "less": "^4.6.4",
-    "matchdep": "^2.0.0",
     "mocha": "^11.7.5",
-    "underscore": "^1.13.8"
+    "underscore": "^1.13.8",
+    "load-grunt-tasks": "^5.1.0"
   },
   "overrides": {
     "diff": "^9.0.0",


### PR DESCRIPTION
Build scripts (grunt/sim-manager.js):
- Replace `touch` with fs.closeSync/openSync (zero-dep timestamp update)
- Replace `fs-extra` removeSync/copySync with native fs.rmSync/cpSync (Node 16+)
- Replace `underscore` _.map/_.reject/_.filter with Array.prototype equivalents

Root package.json:
- Remove touch, fs-extra, underscore, matchdep
- Add load-grunt-tasks ^5.1.0 (maintained successor to matchdep)

All 42 Gruntfile.js files:
- Replace `require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks)`
  with `require('load-grunt-tasks')(grunt)` (one-line drop-in)

All 39 sim + root package.json files:
- Replace matchdep ^1/^2 with load-grunt-tasks ^5.1.0

common/ and common/v3/:
- Remove deprecated bower ^1.3.9
- Remove dead chai-stats ^0.3.0 (last published 2013; no tests use it)
- Upgrade sinon ^1.12.2 → ^19.0.0
- Upgrade chai ^1.10.0 → ^5.0.0
- Update test HTML templates: fix sinon path, remove chai-stats script tag

https://claude.ai/code/session_01PR3n94LXo8YTGHWGU3vWhu